### PR TITLE
Add fade transition on navigation page

### DIFF
--- a/lib/ui/utils/screen_navigation.dart
+++ b/lib/ui/utils/screen_navigation.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 
 void nextScreenPush(BuildContext context, Widget page) {
-  Navigator.push(context, MaterialPageRoute(builder: (context) => page));
+  Navigator.of(context).push(PageRouteBuilder(
+      pageBuilder: (BuildContext context, _, __) => page,
+      transitionsBuilder: (_, Animation<double> animation, __, Widget child) {
+        return FadeTransition(opacity: animation, child: child);
+      }));
 }
 
 void nextScreenCloseOthers(BuildContext context, Widget page) {


### PR DESCRIPTION
Add a fade animation by default when navigate between page. Should create a function for shared axis navigatio, since fade don't fit all use case.

https://m2.material.io/design/motion/the-motion-system.html#transition-patterns